### PR TITLE
Replace #getopenjdk by #getting-started-kit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The pull request will then be reviewed and merged as appropriate
 If you'd like to get involved in AdoptOpenJDK then we recommend you read the [Knowledge Base](README.md) and then:
 
  1. Sign up to the [AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html)
- 1. Drop a message in the _getting-started-kit_ channel and introduce yourself
+ 1. Drop a message in the _general_ channel and introduce yourself
  1. Join the GitHub org (see below)
 
 ## Joining the GitHub Org and Teams

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The pull request will then be reviewed and merged as appropriate
 If you'd like to get involved in AdoptOpenJDK then we recommend you read the [Knowledge Base](README.md) and then:
 
  1. Sign up to the [AdoptOpenJDK Slack](https://adoptopenjdk.net/slack.html)
- 1. Drop a message in the _getopenjdk_ channel and introduce yourself
+ 1. Drop a message in the _getting-started-kit_ channel and introduce yourself
  1. Join the GitHub org (see below)
 
 ## Joining the GitHub Org and Teams


### PR DESCRIPTION
#getopenjdk has been removed, I guess it should be #getting-started-kit